### PR TITLE
Fixes plugin template and build error if missing assets/quasar.variables.style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-quasar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Nuxt module for the Quasar Framework",
   "main": "src/index.js",
   "repository": "https://github.com/NickHurst/nuxt-quasar.git",

--- a/src/module.js
+++ b/src/module.js
@@ -33,7 +33,8 @@ const mergeOptions = (moduleOptions, nuxtOptions, resolver) => {
 
 export default function nuxtQuasar(moduleOptions) {
   const resolver = this.nuxt.resolver || this.nuxt;
-  const pushCSS = file => this.options.css.push(file);
+  const pushCSS = file =>
+    fs.existsSync(file) && this.options.css.push(file);
 
   const options = mergeOptions(moduleOptions, this.options.quasar, resolver);
 

--- a/src/templates/plugin.js
+++ b/src/templates/plugin.js
@@ -26,16 +26,24 @@ import iconSet from 'quasar/icon-set/material-icons.js';
 <% } %>
 
 Vue.use(Quasar, {
+  <% if (config) { %>
   config: <%= JSON.stringify(config, null, '\t') %>,
+  <% } %>
+  <% if (components && components.length) { %>
   components: {
 <%= components.map(s => '\t\t' + s).join(',\n') + ',\n' %>
   },
+  <% } %>
+  <% if (directives && directives.length) { %>
   directives: {
 <%= directives.map(s => '\t\t' + s).join(',\n') + ',\n' %>
   },
+  <% } %>
+  <% if (plugins && plugins.length) { %>
   plugins: {
 <%= plugins.map(s => '\t\t' + s).join(',\n') + ',\n' %>
   },
+  <% } %>
   iconSet,
 });
 <% } %>


### PR DESCRIPTION
Previously if some of quasar's config properties were omitted, the module would generate an invalid plugin (see #1 for more):

```js
Vue.use(Quasar, {
  config: ,
  components: {
,
  },
  directives: {
,
  },
  plugins: {
,
  },
  iconSet,
});
```

Now the properties will only get added if the property exists and is populated in the config, so now the config:

```js
export default {
  mode: 'universal',
  head: {
    title: process.env.npm_package_name || '',
    meta: [
      { charset: 'utf-8' },
      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
      { hid: 'description', name: 'description', content: process.env.npm_package_description || '' }
    ],
    link: [
      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
    ]
  },
  loading: { color: '#fff' },
  modules: [
    'nuxt-quasar',
  ],
  quasar: {
    framework: {
      components: ['QBtn']
    },
  }
}
```

Will generate the plugin file:

```js
import Vue from 'vue';

import Quasar, {
  QBtn,
} from 'quasar/src/index.esm';

import iconSet from 'quasar/icon-set/material-icons.js';

Vue.use(Quasar, {
  components: {
    QBtn,
  },
  iconSet,
});
```

This also fixes a bug where if the `./assets/quasar.variables.styl` file didn't exist the build would fail.